### PR TITLE
Using The Graph to filter events from the Utonoma contract

### DIFF
--- a/MyContent/main.js
+++ b/MyContent/main.js
@@ -43,7 +43,8 @@ async function getContent() {
     //getting the contents
     let contents = []
     for (let i = 0; i < events.length; i++) {
-      contents.push(await getElement(events[i]))
+      contents.push(await getElement(events[i].index, events[i].contentType))
+      //fetch the contents one by one and with a delay to avoid the provider to block the requests
       await delay(300)
     }
     console.log(contents)
@@ -63,13 +64,7 @@ async function getContent() {
   }
 }
 
-async function getElement(element) {
-  const { 
-    0: uploaderAddress, 
-    1: identifierIndex, 
-    2: identifierContentType 
-  } = element.args
-
+async function getElement(index, contentType) {
   const { 
     0: authorAddress, 
     1: contentIdInBytes32, 
@@ -77,7 +72,7 @@ async function getElement(element) {
     3: likes,
     4: dislikes,
     5: harvestedLikes
-  } = await readOnlyProvider.utonomaContract.getContentById([identifierIndex, identifierContentType])
+  } = await readOnlyProvider.utonomaContract.getContentById([index, contentType])
 
   const metadata = await fetch(
     `https://copper-urban-gorilla-864.mypinata.cloud/ipfs/${getIpfsHashFromBytes32(metadataHashInBytes32)}?pinataGatewayToken=WmR3tEcyNtxE6vjc4lPPIrY0Hzp3Dc9AYf2X4Bl-8o6JYBzTx9aY_u3OlpL1wGra`
@@ -92,8 +87,8 @@ async function getElement(element) {
     dislikes,
     harvestedLikes,
     isHarvestable,
-    identifierIndex,
-    identifierContentType
+    identifierIndex: index,
+    identifierContentType: contentType
   }
 }
 

--- a/web3_providers/readOnlyProvider.js
+++ b/web3_providers/readOnlyProvider.js
@@ -6,7 +6,7 @@
 
 import { sepoliaRpcEndpoint, sepoliaEventFilterEndpoint } from './rpcEndpoints.js'
 import { JsonRpcProvider, Contract } from 'ethers'
-import { utonomaSepoliaAddress, utonomaABI, contractDeployedInBlock } from '../utonomaSmartContract.js'
+import { utonomaSepoliaAddress, utonomaABI } from '../utonomaSmartContract.js'
 
 
 export const readOnlyProvider = (function() {
@@ -40,7 +40,34 @@ export const readOnlyProvider = (function() {
      * so many events unnecessarily
      */
     getContentUploadedByThisAccount: async(userAddress) => {
-      return await utonomaContract.queryFilter(utonomaContract.filters.uploaded(userAddress), contractDeployedInBlock, 'latest')
+      try {
+        const rawResponse = await fetch(sepoliaEventFilterEndpoint, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({
+            query: `
+              {
+                uploadeds(
+                  where: {
+                    contentCreator:"${userAddress}"
+                  }
+                  orderBy: index
+                  orderDirection: desc
+                ){
+                  index,
+                  contentType
+                }
+              }
+            `
+          })  
+        })
+        const response = await rawResponse.json()
+        return response.data.uploadeds
+      } catch (error) {
+        throw new Error('Error when filtering the contents uploaded by this account:', error)
+      }
     }
   }
 

--- a/web3_providers/readOnlyProvider.js
+++ b/web3_providers/readOnlyProvider.js
@@ -4,7 +4,7 @@
  * @module readOnlyProvider
  */
 
-import { sepoliaEndpoint } from './rpcEndpoints.js'
+import { sepoliaRpcEndpoint, sepoliaEventFilterEndpoint } from './rpcEndpoints.js'
 import { JsonRpcProvider, Contract } from 'ethers'
 import { utonomaSepoliaAddress, utonomaABI, contractDeployedInBlock } from '../utonomaSmartContract.js'
 
@@ -14,7 +14,7 @@ export const readOnlyProvider = (function() {
    * The JSON-RPC provider to the selected network
    * @type {JsonRpcProvider}
    */
-  let provider = new JsonRpcProvider(sepoliaEndpoint)
+  let provider = new JsonRpcProvider(sepoliaRpcEndpoint)
 
   /**
    * The Utonoma contract instance.

--- a/web3_providers/rpcEndpoints.js
+++ b/web3_providers/rpcEndpoints.js
@@ -1,1 +1,2 @@
-export const sepoliaEndpoint = 'https://sepolia-rpc.scroll.io/'
+export const sepoliaRpcEndpoint = 'https://sepolia-rpc.scroll.io/'
+export const sepoliaEventFilterEndpoint = 'https://api.studio.thegraph.com/query/106360/utonoma-sepolia-get-contents-uploaded/version/latest'

--- a/web3_providers/signedProvider.js
+++ b/web3_providers/signedProvider.js
@@ -3,7 +3,6 @@ import { EthersAdapter } from '@reown/appkit-adapter-ethers'
 import { scrollSepolia, scroll } from '@reown/appkit/networks'
 import { BrowserProvider, Contract } from 'ethers'
 import { utonomaSepoliaAddress, utonomaABI } from '../utonomaSmartContract.js'
-import { sepoliaEndpoint } from './rpcEndpoints.js'
 
 let modal
 


### PR DESCRIPTION
Previously, event data was queried from RPC providers, which only track recent events, causing issues when fetching past events. To resolve this, we now use The Graph, a service that allows querying historical events emitted by the Utonoma contract using GraphQL filters.